### PR TITLE
Don't set the LIBRARY_PATH environment variable.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -50,9 +50,10 @@ function set-env (){
   echo "export $1=\$$1:$2" >> $EXPORT_PATH
 }
 
+# appends to a colon-delimited envvar
 function set-default-env (){
-  echo "export $1=\${$1:-$2}" >> $PROFILE_PATH
-  echo "export $1=\$$1:$2" >> $EXPORT_PATH
+  echo "export $1=\$$1\${$1:+:}$2" >> $PROFILE_PATH
+  echo "export $1=\$$1\${$1:+:}$2" >> $EXPORT_PATH
 }
 
 # Retrieve versions


### PR DESCRIPTION
LIBRARY_PATH is for gcc linker scripts and seems unnecessary here.
It's causing issues because LIBRARY_PATH is set to a value including a bare
colon (e.g. ":/blah/blah") which causes GCC to search the current directory.
That breaks the compilation of some python modules (specifically guppy)
